### PR TITLE
feat: use rust 1.60.0s new feature syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/kurtlawrence/guid-create"
 readme = "README.md"
 keywords = ["guid"]
 license = "MIT"
+rust-version="1.60.0"
 
 [dependencies]
 rand = "0.8.4"
@@ -14,7 +15,10 @@ guid = "0.1.0"
 byteorder = "1.4.3"
 guid-parser = "0.1.0"
 chomp = "0.3.1"
-serde = {version="1.0.130", optional = true}
+serde = { version = "1.0.130", optional = true }
+
+[features]
+serde = ["dep:serde"]
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"


### PR DESCRIPTION
Cargo with rust 1.60.0 has a new way of declaring features with the same name as crates, lets adopt it.

Changing nothing wouldn’t break the crate