### PR TITLE
style: newer format! syntax

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,7 +291,7 @@ impl<'de> Deserialize<'de> for GUID {
     {
         let string_guid = String::deserialize(deserializer)?;
         let guid = GUID::parse(&string_guid)
-            .map_err(|_| de::Error::custom(format!("cannot convert {} to guid", string_guid)))?;
+            .map_err(|_| de::Error::custom(format!("cannot convert {string_guid} to guid")))?;
         Ok(guid)
     }
 }


### PR DESCRIPTION
I'm just cycling over some crates for maintenance.

`format!` is just used once but as It see it, it just makes it reading easier as local variables can be used as named parameters.

For the `write!` statements, yes there are two but either they use the output of functions or have no parameters