### PR TITLE
Handroll parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "guid-create"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["kurt <kurtlawrence92@gmail.com>"]
 description = "Rust helper for creating GUIDs"
 repository = "https://github.com/kurtlawrence/guid-create"
@@ -11,10 +11,8 @@ edition = "2021"
 rust-version="1.60.0"
 
 [dependencies]
-rand = "0.8.4"
-guid-parser = "0.1.0"
-chomp = "0.3.1"
-serde = { version = "1.0.130", optional = true }
+rand = "0.8"
+serde = { version = "1", optional = true }
 
 [features]
 serde = ["dep:serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,7 @@ serde = ["dep:serde"]
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"
+
+[dev-dependencies]
+quickcheck = "1"
+quickcheck_macros = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,6 @@ extern crate quickcheck;
 #[macro_use(quickcheck)]
 extern crate quickcheck_macros;
 
-use chomp::prelude::*;
 use std::{convert::TryInto, fmt};
 
 #[cfg(windows)]
@@ -105,7 +104,6 @@ impl GUID {
     }
 
     /// Construct a `GUID` from a string.
-    /// Leverages [`guid-parser`](https://docs.rs/guid-parser/0.1.0/guid_parser/index.html) for the parsing.
     ///
     /// ``` rust
     /// let guid = guid_create::GUID::parse("87935CDE-7094-4C2B-A0F4-DD7D512DD261").unwrap();
@@ -356,14 +354,9 @@ impl fmt::Display for GUID {
             self.data1(),
             self.data2(),
             self.data3(),
-            u16::from_be_bytes([self.data4()[0], self.data4()[1]]),
-            u32::from_be_bytes([
-                self.data4()[2],
-                self.data4()[3],
-                self.data4()[4],
-                self.data4()[5],
-            ]),
-            u16::from_be_bytes([self.data4()[6], self.data4()[7]]),
+            u16::from_be_bytes(self.data[8..10].try_into().unwrap()),
+            u32::from_be_bytes(self.data[10..14].try_into().unwrap()),
+            u16::from_be_bytes(self.data[14..16].try_into().unwrap()),
         )
     }
 }


### PR DESCRIPTION
To close #13, `chomp` and `guid-parser` needed to be removed.
The only influenced the parsing function, so I have hand rolled the parsing (it is also twice as fast now) and removed the dependencies, and did some minor clean up of the code.