### PR TITLE
impl std::error::Error for ParseError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,8 @@ impl fmt::Display for ParseError {
     }
 }
 
+impl std::error::Error for ParseError {}
+
 /// A GUID backed by 16 byte array.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Hash)]
 pub struct GUID {


### PR DESCRIPTION
Otherwise certain features associated with error handling in the standard library or even in external crates like anyhow can't be used with ParseError