### PR TITLE
Add support for bytemuck

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,11 @@ rust-version="1.60.0"
 [dependencies]
 rand = "0.8"
 serde = { version = "1", optional = true }
+bytemuck = { version = "1", optional = true }
 
 [features]
 serde = ["dep:serde"]
+bytemuck = ["dep:bytemuck"]
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,8 @@ impl fmt::Display for ParseError {
     }
 }
 
+impl std::error::Error for ParseError {}
+
 /// A GUID backed by 16 byte array.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Hash)]
 pub struct GUID {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,8 @@ impl std::error::Error for ParseError {}
 
 /// A GUID backed by 16 byte array.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Hash)]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[repr(transparent)]
 pub struct GUID {
     data: [u8; 16],
 }


### PR DESCRIPTION
Bytemuck allows to cast types into other types and to get the byte representation of a type or a slice or `Vec`of that type. With this change for example one can do:

```rs
let guids = vec![GUID::rand();100];
std::fs::write("guids.bin", bytemuck::cast_slice(&guids))?;
```

To write several GUIDs as binary data to a file or other stream.