### PR TITLE
feat: enable no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,13 @@ edition = "2021"
 rust-version="1.60.0"
 
 [dependencies]
-rand = "0.8"
+rand = { version = "0.8", optional = true }
 serde = { version = "1", optional = true }
 bytemuck = { version = "1", optional = true }
 
 [features]
+default = ["rand"]
+rand = ["dep:rand"]
 serde = ["dep:serde"]
 bytemuck = ["dep:bytemuck"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ serde = { version = "1", optional = true }
 bytemuck = { version = "1", optional = true }
 
 [features]
-default = ["rand"]
+default = ["std", "rand"]
+std = []
 rand = ["dep:rand"]
 serde = ["dep:serde"]
 bytemuck = ["dep:bytemuck"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,7 @@ impl GUID {
     }
 
     /// Generates a new GUID with 16 random bytes.
+    #[cfg(feature = "rand")]
     pub fn rand() -> GUID {
         GUID {
             data: rand::random(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 //! # guid-create
 //!
 //! Rust helper for randomly creating GUIDs.
@@ -27,7 +28,7 @@ extern crate quickcheck;
 #[macro_use(quickcheck)]
 extern crate quickcheck_macros;
 
-use std::{convert::TryInto, fmt};
+use core::{convert::TryInto, fmt};
 
 #[cfg(windows)]
 use winapi::shared::guiddef::GUID as WinGuid;
@@ -44,8 +45,7 @@ impl fmt::Display for ParseError {
         )
     }
 }
-
-impl std::error::Error for ParseError {}
+impl core::error::Error for ParseError {}
 
 /// A GUID backed by 16 byte array.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default, Hash)]


### PR DESCRIPTION
Dependencies that run in no_std environment can now work by using: `default-features = false`